### PR TITLE
Support go-get install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ existing tools (like `docker-compose`) keep working without changes.
 ## Installation
 
 ```
-go install ./...
+go install github.com/yudppp/go-svc@latest
 ```
 
 ## Usage
@@ -25,6 +25,18 @@ git svc clean packages/a
 
 # list managed symlinks
 git svc list
+```
+
+## Using as a library
+
+Fetch the module with `go get` and import the `svc` package:
+
+```bash
+go get github.com/yudppp/go-svc
+```
+
+```go
+import "github.com/yudppp/go-svc/svc"
 ```
 
 ## Configuration

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -1,8 +1,8 @@
 package cmd
 
 import (
-	"git-svc/svc"
 	"github.com/spf13/cobra"
+	"github.com/yudppp/go-svc/svc"
 )
 
 var cleanCmd = &cobra.Command{

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,8 +1,8 @@
 package cmd
 
 import (
-	"git-svc/svc"
 	"github.com/spf13/cobra"
+	"github.com/yudppp/go-svc/svc"
 )
 
 var initCmd = &cobra.Command{

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -3,8 +3,8 @@ package cmd
 import (
 	"fmt"
 
-	"git-svc/svc"
 	"github.com/spf13/cobra"
+	"github.com/yudppp/go-svc/svc"
 )
 
 var listCmd = &cobra.Command{

--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -1,8 +1,8 @@
 package cmd
 
 import (
-	"git-svc/svc"
 	"github.com/spf13/cobra"
+	"github.com/yudppp/go-svc/svc"
 )
 
 var pullCmd = &cobra.Command{

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module git-svc
+module github.com/yudppp/go-svc
 
 go 1.23.8
 

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "git-svc/cmd"
+import "github.com/yudppp/go-svc/cmd"
 
 func main() {
 	cmd.Execute()


### PR DESCRIPTION
## Summary
- update module path to `github.com/yudppp/go-svc`
- adjust imports for new path
- document installation using `go install github.com/yudppp/go-svc@latest`
- add instructions for using the `svc` package as a library

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_6847f793b6f88325b6adf726ac033199