### PR TITLE
Rename go-svc references to git-svc

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ existing tools (like `docker-compose`) keep working without changes.
 ## Installation
 
 ```
-go install github.com/yudppp/go-svc@latest
+go install github.com/yudppp/git-svc@latest
 ```
 
 ## Usage
@@ -32,11 +32,11 @@ git svc list
 Fetch the module with `go get` and import the `svc` package:
 
 ```bash
-go get github.com/yudppp/go-svc
+go get github.com/yudppp/git-svc
 ```
 
 ```go
-import "github.com/yudppp/go-svc/svc"
+import "github.com/yudppp/git-svc/svc"
 ```
 
 ## Configuration

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -2,7 +2,7 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
-	"github.com/yudppp/go-svc/svc"
+	"github.com/yudppp/git-svc/svc"
 )
 
 var cleanCmd = &cobra.Command{

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -2,7 +2,7 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
-	"github.com/yudppp/go-svc/svc"
+	"github.com/yudppp/git-svc/svc"
 )
 
 var initCmd = &cobra.Command{

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/yudppp/go-svc/svc"
+	"github.com/yudppp/git-svc/svc"
 )
 
 var listCmd = &cobra.Command{

--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -2,7 +2,7 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
-	"github.com/yudppp/go-svc/svc"
+	"github.com/yudppp/git-svc/svc"
 )
 
 var pullCmd = &cobra.Command{

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/yudppp/go-svc
+module github.com/yudppp/git-svc
 
 go 1.23.8
 

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/yudppp/go-svc/cmd"
+import "github.com/yudppp/git-svc/cmd"
 
 func main() {
 	cmd.Execute()


### PR DESCRIPTION
## Summary
- rename module path and imports from `go-svc` to `git-svc`
- update README instructions

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_6847fb2da1688325bf296bafdce76fdd