### PR TITLE
Add sparse-checkout to git svc init

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 # git-svc
 
 git-svc is a small CLI tool that wraps `git worktree` operations and
-creates symlinks for local development. It allows you to check out
-branches into a separate directory and link service directories so that
-existing tools (like `docker-compose`) keep working without changes.
+creates symlinks for local development. Worktrees are added with
+`git worktree add --no-checkout` and then configured using
+`git sparse-checkout` so that only the specified directory is
+checked out. This keeps worktrees lightweight while
+ensuring existing tools (like `docker-compose`) keep working without
+changes.
 
 ## Installation
 
@@ -15,6 +18,7 @@ go install github.com/yudppp/git-svc@latest
 
 ```
 # add worktree for branch feature and link packages/a
+# only packages/a will be checked out using git sparse-checkout
 git svc init packages/a feature
 
 # pull latest changes for the worktree linked from packages/a
@@ -50,10 +54,13 @@ Example:
 ```bash
 $ GITSVC_WORKTREE_ROOT=_trees git svc init packages/b other-branch
 ```
+Only `packages/b` will exist in the created worktree thanks to
+`git worktree add --no-checkout` and `git sparse-checkout`.
 
 ### Typical workflow
 
-1. Initialize a branch-specific worktree linked to your service:
+1. Initialize a branch-specific worktree linked to your service
+   (only that directory will be checked out):
    ```bash
    git svc init packages/a feature
    ```

--- a/svc/service.go
+++ b/svc/service.go
@@ -25,7 +25,16 @@ func Init(dir, branch, root string) error {
 		return err
 	}
 	worktreePath := filepath.Join(repoRoot, root, branch)
-	if err := runCmd(repoRoot, "git", "worktree", "add", worktreePath, branch); err != nil {
+	if err := runCmd(repoRoot, "git", "worktree", "add", "--no-checkout", worktreePath, branch); err != nil {
+		return err
+	}
+	if err := runCmd(worktreePath, "git", "sparse-checkout", "init", "--cone"); err != nil {
+		return err
+	}
+	if err := runCmd(worktreePath, "git", "sparse-checkout", "set", dir); err != nil {
+		return err
+	}
+	if err := runCmd(worktreePath, "git", "reset", "--hard", "HEAD"); err != nil {
 		return err
 	}
 	target := filepath.Join(worktreePath, dir)

--- a/svc/service_test.go
+++ b/svc/service_test.go
@@ -52,6 +52,14 @@ func TestInitPullCleanList(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	entries, err := os.ReadDir(filepath.Join(repo, ".worktrees", "feature", "packages"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "a" {
+		t.Fatalf("sparse checkout not applied: %v", entries)
+	}
+
 	m, err := List(".worktrees")
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Summary
- create sparse checkout after adding a worktree
- document sparse checkout behaviour in README
- test that only the requested directory is checked out
- add `--no-checkout` option when creating the worktree

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_68480825e6d8832595e69f3d1228685e