### PR TITLE
Ignore permission errors in list command

### DIFF
--- a/svc/service.go
+++ b/svc/service.go
@@ -89,6 +89,10 @@ func List(root string) (map[string]string, error) {
 	m := make(map[string]string)
 	err = filepath.WalkDir(repoRoot, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
+			if os.IsPermission(err) {
+				// Ignore permission errors and continue walking
+				return nil
+			}
 			return err
 		}
 		if d.Type()&os.ModeSymlink == 0 {


### PR DESCRIPTION
## Summary
- ignore `os.IsPermission` errors when listing worktrees

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_68480e476230832584f1cb2dd198d6ee