### PR TITLE
Remove sparse checkout usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
 # git-svc
 
 git-svc is a small CLI tool that wraps `git worktree` operations and
-creates symlinks for local development. Worktrees are added with
-`git worktree add --no-checkout` and then configured using
-`git sparse-checkout` so that only the specified directory is
-checked out. This keeps worktrees lightweight while
-ensuring existing tools (like `docker-compose`) keep working without
-changes.
+creates symlinks for local development. Each linked directory is backed
+by its own worktree created with `git worktree add`. All files for the
+branch are checked out so existing tools (like `docker-compose`) keep
+working without any special configuration.
 
 ## Installation
 
@@ -18,7 +16,6 @@ go install github.com/yudppp/git-svc@latest
 
 ```
 # add worktree for branch feature and link packages/a
-# only packages/a will be checked out using git sparse-checkout
 git svc init packages/a feature
 
 # pull latest changes for the worktree linked from packages/a
@@ -54,13 +51,12 @@ Example:
 ```bash
 $ GITSVC_WORKTREE_ROOT=_trees git svc init packages/b other-branch
 ```
-Only `packages/b` will exist in the created worktree thanks to
-`git worktree add --no-checkout` and `git sparse-checkout`.
+This creates a worktree under `_trees/other-branch` and links
+`packages/b` to it.
 
 ### Typical workflow
 
-1. Initialize a branch-specific worktree linked to your service
-   (only that directory will be checked out):
+1. Initialize a branch-specific worktree linked to your service:
    ```bash
    git svc init packages/a feature
    ```

--- a/svc/service.go
+++ b/svc/service.go
@@ -27,16 +27,7 @@ func Init(dir, branch, root string) error {
 		return err
 	}
 	worktreePath := filepath.Join(repoRoot, root, branch)
-	if err := runCmd(repoRoot, "git", "worktree", "add", "--no-checkout", worktreePath, branch); err != nil {
-		return err
-	}
-	if err := runCmd(worktreePath, "git", "sparse-checkout", "init", "--cone"); err != nil {
-		return err
-	}
-	if err := runCmd(worktreePath, "git", "sparse-checkout", "set", dir); err != nil {
-		return err
-	}
-	if err := runCmd(worktreePath, "git", "reset", "--hard", "HEAD"); err != nil {
+	if err := runCmd(repoRoot, "git", "worktree", "add", worktreePath, branch); err != nil {
 		return err
 	}
 	target := filepath.Join(worktreePath, dir)

--- a/svc/service_test.go
+++ b/svc/service_test.go
@@ -59,12 +59,8 @@ func TestInitPullCleanList(t *testing.T) {
 		t.Fatalf("backup not created: %v", err)
 	}
 
-	entries, err := os.ReadDir(filepath.Join(repo, ".worktrees", "feature", "packages"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(entries) != 1 || entries[0].Name() != "a" {
-		t.Fatalf("sparse checkout not applied: %v", entries)
+	if _, err := os.Stat(filepath.Join(repo, ".worktrees", "feature", "packages", "a", "file.txt")); err != nil {
+		t.Fatalf("worktree file missing: %v", err)
 	}
 
 	m, err := List(".worktrees")


### PR DESCRIPTION
## Summary
- checkout full worktrees instead of using sparse checkout
- document the simpler behavior in the README
- update tests accordingly

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_684812b7303c832596a4fba6cd483fa5