### PR TITLE
Support branching from base in init

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,11 @@ go install github.com/yudppp/git-svc@latest
 ## Usage
 
 ```
-# add worktree for branch feature and link packages/a
+# add worktree for an existing branch and link packages/a
 git svc init packages/a feature
+
+# create a new branch from origin/main and link packages/a
+git svc init packages/a -b feat-a origin/main
 
 # pull latest changes for the worktree linked from packages/a
 git svc pull packages/a
@@ -58,7 +61,7 @@ This creates a worktree under `_trees/other-branch` and links
 
 1. Initialize a branch-specific worktree linked to your service:
    ```bash
-   git svc init packages/a feature
+   git svc init packages/a -b feature
    ```
 2. Keep the worktree up to date:
    ```bash

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,19 +1,35 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 	"github.com/yudppp/git-svc/svc"
 )
 
+var branchFlag string
+
 var initCmd = &cobra.Command{
-	Use:   "init <dir> <branch>",
+	Use:   "init <dir> [base]",
 	Short: "add worktree and link directory",
-	Args:  cobra.ExactArgs(2),
+	Args:  cobra.RangeArgs(1, 2),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return svc.Init(args[0], args[1], worktreeRoot)
+		dir := args[0]
+		if branchFlag != "" {
+			var base string
+			if len(args) == 2 {
+				base = args[1]
+			}
+			return svc.Init(dir, branchFlag, base, worktreeRoot, true)
+		}
+		if len(args) < 2 {
+			return fmt.Errorf("branch required")
+		}
+		return svc.Init(dir, args[1], "", worktreeRoot, false)
 	},
 }
 
 func init() {
+	initCmd.Flags().StringVarP(&branchFlag, "branch", "b", "", "create new branch")
 	rootCmd.AddCommand(initCmd)
 }

--- a/svc/service.go
+++ b/svc/service.go
@@ -21,13 +21,24 @@ func RepoRoot() (string, error) {
 }
 
 // Init adds a worktree for the branch and links the directory to it.
-func Init(dir, branch, root string) error {
+// If create is true, a new branch is created with `-b branch` and optionally
+// based on the provided base commitish.
+func Init(dir, branch, base, root string, create bool) error {
 	repoRoot, err := RepoRoot()
 	if err != nil {
 		return err
 	}
 	worktreePath := filepath.Join(repoRoot, root, branch)
-	if err := runCmd(repoRoot, "git", "worktree", "add", worktreePath, branch); err != nil {
+	args := []string{"git", "worktree", "add"}
+	if create {
+		args = append(args, "-b", branch, worktreePath)
+		if base != "" {
+			args = append(args, base)
+		}
+	} else {
+		args = append(args, worktreePath, branch)
+	}
+	if err := runCmd(repoRoot, args[0], args[1:]...); err != nil {
 		return err
 	}
 	target := filepath.Join(worktreePath, dir)


### PR DESCRIPTION
## Summary
- allow `git svc init` to create a new branch from a specified base
- add `-b` flag to choose branch name
- update docs and workflow examples
- test creating a branch from `origin/master`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_b_6848150839b0832599f4c5bf0208b12d