### PR TITLE
Add sparse checkout option

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ go install github.com/yudppp/git-svc@latest
 # add worktree for an existing branch and link packages/a
 git svc init packages/a feature
 
+# only checkout packages/a using sparse checkout
+git svc init --sparse packages/a feature
+
 # create a new branch from origin/main and link packages/a
 git svc init packages/a -b feat-a origin/main
 
@@ -52,16 +55,16 @@ Set a custom worktree root with the `--worktree-root` flag or the
 Example:
 
 ```bash
-$ GITSVC_WORKTREE_ROOT=_trees git svc init packages/b other-branch
+$ GITSVC_WORKTREE_ROOT=_trees git svc init --sparse packages/b other-branch
 ```
 This creates a worktree under `_trees/other-branch` and links
-`packages/b` to it.
+`packages/b` to it while only checking out that directory.
 
 ### Typical workflow
 
 1. Initialize a branch-specific worktree linked to your service:
    ```bash
-   git svc init packages/a -b feature
+   git svc init --sparse packages/a -b feature
    ```
 2. Keep the worktree up to date:
    ```bash

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -8,6 +8,7 @@ import (
 )
 
 var branchFlag string
+var sparseFlag bool
 
 var initCmd = &cobra.Command{
 	Use:   "init <dir> [base]",
@@ -20,16 +21,17 @@ var initCmd = &cobra.Command{
 			if len(args) == 2 {
 				base = args[1]
 			}
-			return svc.Init(dir, branchFlag, base, worktreeRoot, true)
+			return svc.Init(dir, branchFlag, base, worktreeRoot, true, sparseFlag)
 		}
 		if len(args) < 2 {
 			return fmt.Errorf("branch required")
 		}
-		return svc.Init(dir, args[1], "", worktreeRoot, false)
+		return svc.Init(dir, args[1], "", worktreeRoot, false, sparseFlag)
 	},
 }
 
 func init() {
 	initCmd.Flags().StringVarP(&branchFlag, "branch", "b", "", "create new branch")
+	initCmd.Flags().BoolVar(&sparseFlag, "sparse", false, "use git sparse-checkout")
 	rootCmd.AddCommand(initCmd)
 }


### PR DESCRIPTION
## Summary
- support sparse checkout on init
- expose `--sparse` flag in CLI
- document sparse usage in README
- test sparse mode

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_b_68481a0011088325abebbc26a1c00427